### PR TITLE
armani: power: update power profiles with latest changes.

### DIFF
--- a/power/power.c
+++ b/power/power.c
@@ -137,8 +137,8 @@ static void set_power_profile(int profile)
                     profiles[profile].io_is_busy);
     sysfs_write_int(INTERACTIVE_PATH "min_sample_time",
                     profiles[profile].min_sample_time);
-    sysfs_write_int(INTERACTIVE_PATH "sampling_down_factor",
-                    profiles[profile].sampling_down_factor);
+    sysfs_write_int(INTERACTIVE_PATH "max_freq_hysteresis",
+                    profiles[profile].max_freq_hysteresis);
     sysfs_write_str(INTERACTIVE_PATH "target_loads",
                     profiles[profile].target_loads);
     sysfs_write_int(CPUFREQ_PATH "scaling_max_freq",

--- a/power/power.h
+++ b/power/power.h
@@ -32,7 +32,7 @@ typedef struct governor_settings {
     int hispeed_freq_off;
     int io_is_busy;
     int min_sample_time;
-    int sampling_down_factor;
+    int max_freq_hysteresis;
     char *target_loads;
     char *target_loads_off;
     int scaling_max_freq;
@@ -50,7 +50,7 @@ static power_profile profiles[PROFILE_MAX] = {
         .hispeed_freq_off = 787200,
         .io_is_busy = 0,
         .min_sample_time = 60000,
-        .sampling_down_factor = 100000,
+        .max_freq_hysteresis = 100000,
         .target_loads = "95",
         .target_loads_off = "95",
         .scaling_max_freq = 787200,
@@ -66,7 +66,7 @@ static power_profile profiles[PROFILE_MAX] = {
         .hispeed_freq_off = 787200,
         .io_is_busy = 1,
         .min_sample_time = 60000,
-        .sampling_down_factor = 100000,
+        .max_freq_hysteresis = 100000,
         .target_loads = "80 998400:90 1401600:99",
         .target_loads_off = "95 1401600:99",
         .scaling_max_freq = 1401600,
@@ -84,7 +84,7 @@ static power_profile profiles[PROFILE_MAX] = {
         .hispeed_freq_off = 998400,
         .io_is_busy = 1,
         .min_sample_time = 60000,
-        .sampling_down_factor = 100000,
+        .max_freq_hysteresis = 100000,
         .target_loads = "80",
         .target_loads_off = "80",
         .scaling_max_freq = 1593600,
@@ -100,7 +100,7 @@ static power_profile profiles[PROFILE_MAX] = {
         .hispeed_freq_off = 787200,
         .io_is_busy = 0,
         .min_sample_time = 60000,
-        .sampling_down_factor = 100000,
+        .max_freq_hysteresis = 100000,
         .target_loads = "90",
         .target_loads_off = "95",
         .scaling_max_freq = 1190400,


### PR DESCRIPTION
* replace "sampling_down_factor" as it is deprecated, we now using "max_freq_hysteresis".

Source: https://github.com/CyanogenMod/android_kernel_xiaomi_armani/commit/f1e1e312fb9215815597e7594f693a7258e3a81d